### PR TITLE
Add project name to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "name": "bixie/egcs-client",
     "require": {
         "guzzlehttp/guzzle": "^6.3",
         "kamermans/guzzle-oauth2-subscriber": "^1.0"


### PR DESCRIPTION
This allows the repository to be required by composer, for as long as
the package is not on packagist yet